### PR TITLE
Reduce the minimum framework requirements for the expression parser 

### DIFF
--- a/Tethys.SPDX.ExpressionParser/Tethys.SPDX.ExpressionParser.csproj
+++ b/Tethys.SPDX.ExpressionParser/Tethys.SPDX.ExpressionParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>disable</Nullable>
 	  <CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Reduce the minimum framework requirements for the expression parser for it to be used in .net framework applications