### PR TITLE
multitarget in order to avoid System.Text.Json dependency when it is not needed

### DIFF
--- a/Tethys.SPDX.Interfaces/Tethys.SPDX.Interfaces.csproj
+++ b/Tethys.SPDX.Interfaces/Tethys.SPDX.Interfaces.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -22,12 +22,15 @@ SPDX-License-Identifier: Apache-2.0
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 		<None Include="..\tethys_spdx_icon.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
 		</None>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net6.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/Tethys.SPDX.KnownLicenses.Test/Tethys.SPDX.KnownLicenses.Test.csproj
+++ b/Tethys.SPDX.KnownLicenses.Test/Tethys.SPDX.KnownLicenses.Test.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>netframework472;net6.0;net7.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tethys.SPDX.KnownLicenses/Tethys.SPDX.KnownLicenses.csproj
+++ b/Tethys.SPDX.KnownLicenses/Tethys.SPDX.KnownLicenses.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -22,16 +22,19 @@ SPDX-License-Identifier: Apache-2.0
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
 		<PackageReference Include="Tethys.Logging" Version="1.6.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Tethys.SPDX.Interfaces\Tethys.SPDX.Interfaces.csproj" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 		<None Include="..\tethys_spdx_icon.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
 

--- a/Tethys.SPDX.SimpleSpdxParser.Test/Tethys.SPDX.SimpleSpdxParser.Test.csproj
+++ b/Tethys.SPDX.SimpleSpdxParser.Test/Tethys.SPDX.SimpleSpdxParser.Test.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>netframework472;net6.0;net7.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tethys.SPDX.SimpleSpdxParser/Tethys.SPDX.SimpleSpdxParser.csproj
+++ b/Tethys.SPDX.SimpleSpdxParser/Tethys.SPDX.SimpleSpdxParser.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Since .net already includes System.Text.Json, the nuget package is only needed if targeting a version that does not support all features used. This PR makes sure the nuget package will not contain "unndecessary" dependencies.