### PR TITLE
Have correct operator precedence: `AND` has higher precedence than `OR`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # Tethys.SPDX
 
+## NEXT
+
+* Have correct operator precedence: `AND` has higher precedence than `OR`.
+
 ## 2.1.2 (2024-05-08)
 
 * Fixing SPDX validation issues

--- a/Tethys.SPDX.ExpressionParser.Test/Tethys.SPDX.ExpressionParser.Test.csproj
+++ b/Tethys.SPDX.ExpressionParser.Test/Tethys.SPDX.ExpressionParser.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tethys.SPDX.ExpressionParser/SpdxExpressionParser.cs
+++ b/Tethys.SPDX.ExpressionParser/SpdxExpressionParser.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------
 // <copyright file="SpdxExpressionParser.cs" company="Tethys">
-//   Copyright (C) 2023-2024 T. Graf
+//   Copyright (C) 2023-2025 T. Graf
 // </copyright>
 //
 // Licensed under the Apache License, Version 2.0.
@@ -97,7 +97,7 @@ namespace Tethys.SPDX.ExpressionParser
                 throw new SpdxExpressionException(string.Empty);
             } // if
 
-            var expr = ParseAnd();
+            var expr = ParseOr();
 
             return expr;
         } // Parse()
@@ -107,24 +107,6 @@ namespace Tethys.SPDX.ExpressionParser
         /// </summary>
         /// <returns>A <see cref="SpdxExpression"/>.</returns>
         private static SpdxExpression ParseAnd()
-        {
-            var expression = ParseOr();
-            var currentToken = GetCurrentToken();
-            while (currentToken?.Type == TokenType.And)
-            {
-                GetNextToken();
-                expression = new SpdxAndExpression(expression, ParseOr());
-                currentToken = GetCurrentToken();
-            } // while
-
-            return expression;
-        } // ParseAnd()
-
-        /// <summary>
-        /// Parses an "or" expression.
-        /// </summary>
-        /// <returns>A <see cref="SpdxExpression"/>.</returns>
-        private static SpdxExpression ParseOr()
         {
             SpdxExpression expression;
             var currentToken = GetCurrentToken();
@@ -138,10 +120,28 @@ namespace Tethys.SPDX.ExpressionParser
             } // if
 
             currentToken = GetCurrentToken();
-            while (currentToken.Type == TokenType.Or)
+            while (currentToken.Type == TokenType.And)
             {
                 GetNextToken();
-                expression = new SpdxOrExpression(expression, ParseOr());
+                expression = new SpdxAndExpression(expression, ParseAnd());
+                currentToken = GetCurrentToken();
+            } // while
+
+            return expression;
+        } // ParseAnd()
+
+        /// <summary>
+        /// Parses an "or" expression.
+        /// </summary>
+        /// <returns>A <see cref="SpdxExpression"/>.</returns>
+        private static SpdxExpression ParseOr()
+        {
+            var expression = ParseAnd();
+            var currentToken = GetCurrentToken();
+            while (currentToken?.Type == TokenType.Or)
+            {
+                GetNextToken();
+                expression = new SpdxOrExpression(expression, ParseAnd());
                 currentToken = GetCurrentToken();
             } // while
 
@@ -155,7 +155,7 @@ namespace Tethys.SPDX.ExpressionParser
         private static SpdxExpression ParseScopedExpression()
         {
             GetNextToken();
-            var expression = ParseAnd();
+            var expression = ParseOr();
             if (GetCurrentToken().Type != TokenType.Right)
             {
                 throw new SpdxExpressionException("Unexpected end of expression.");

--- a/Tethys.SPDX.Interfaces/Tethys.SPDX.Interfaces.csproj
+++ b/Tethys.SPDX.Interfaces/Tethys.SPDX.Interfaces.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net6.0'">
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/Tethys.SPDX.KnownLicenses.Test/Tethys.SPDX.KnownLicenses.Test.csproj
+++ b/Tethys.SPDX.KnownLicenses.Test/Tethys.SPDX.KnownLicenses.Test.csproj
@@ -6,24 +6,24 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netframework472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netframework48;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tethys.SPDX.KnownLicenses/Tethys.SPDX.KnownLicenses.csproj
+++ b/Tethys.SPDX.KnownLicenses/Tethys.SPDX.KnownLicenses.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tethys.SPDX.Model.Test/Tethys.SPDX.Model.Test.csproj
+++ b/Tethys.SPDX.Model.Test/Tethys.SPDX.Model.Test.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tethys.SPDX.SimpleSpdxParser.Test/Tethys.SPDX.SimpleSpdxParser.Test.csproj
+++ b/Tethys.SPDX.SimpleSpdxParser.Test/Tethys.SPDX.SimpleSpdxParser.Test.csproj
@@ -6,24 +6,24 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netframework472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netframework48;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tethys.SPDX.SimpleSpdxParser/Tethys.SPDX.SimpleSpdxParser.csproj
+++ b/Tethys.SPDX.SimpleSpdxParser/Tethys.SPDX.SimpleSpdxParser.csproj
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\Dotnet.ruleset</CodeAnalysisRuleSet>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Code has been reordered to have correct operator precedence.